### PR TITLE
Fix readme links from gp-setup-docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 Storybook is here:
 
-- Production: <https://ucsb-cs156-w22.github.io/team02-w22-6pm-1/>
-- QA: <https://ucsb-cs156-w22.github.io/team02-w22-6pm-1-qa/>
+- Production: <https://ucsb-cs156-w22.github.io/team02-w22-6pm-1-docs/>
+- QA: <https://ucsb-cs156-w22.github.io/team02-w22-6pm-1-docs-qa/>
 
 The GitHub actions script to deploy the Storybook to QA requires some configuration; see [docs/github-actions.md](docs/github-actions.md) for details.
 


### PR DESCRIPTION
In this PR we correct the links in the readme to the docs and docs-qa github pages sites